### PR TITLE
Add capability to subset channels, cloud type shortcuts, and specify cloud and aerosol coefficient files

### DIFF
--- a/discover_modules_gnu.csh
+++ b/discover_modules_gnu.csh
@@ -6,5 +6,5 @@ setenv OPT /discover/swdev/jcsda/modules
 module use $OPT/modulefiles
 module use $OPT/modulefiles/apps
 module use $OPT/modulefiles/core
-module load jedi/gnu-impi/9.2.0
+module load jedi/gnu-impi
 module list

--- a/discover_modules_gnu.sh
+++ b/discover_modules_gnu.sh
@@ -6,5 +6,5 @@ export OPT='/discover/swdev/jcsda/modules'
 module use $OPT/modulefiles
 module use $OPT/modulefiles/apps
 module use $OPT/modulefiles/core
-module load jedi/gnu-impi/9.2.0
+module load jedi/gnu-impi
 module list

--- a/discover_modules_intel.csh
+++ b/discover_modules_intel.csh
@@ -6,5 +6,5 @@ setenv OPT /discover/swdev/jcsda/modules
 module use $OPT/modulefiles
 module use $OPT/modulefiles/apps
 module use $OPT/modulefiles/core
-module load jedi/intel-impi/19.1.0.166-v0.4
+module load jedi/intel-impi
 module list

--- a/discover_modules_intel.sh
+++ b/discover_modules_intel.sh
@@ -6,5 +6,5 @@ export OPT='/discover/swdev/jcsda/modules'
 module use $OPT/modulefiles
 module use $OPT/modulefiles/apps
 module use $OPT/modulefiles/core
-module load jedi/intel-impi/19.1.0.166-v0.4
+module load jedi/intel-impi
 module list

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def main():
     requires=['numpy']
     setup(
         name="pyCRTM_JCSDA",
-        version='1.0.0',
+        version='1.0.1',
         description='Python wrapper for the CRTM.',
         author='Bryan Karpowicz',
         requires=requires,

--- a/testCases/test_atms_subset.py
+++ b/testCases/test_atms_subset.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+import os, h5py, sys 
+import numpy as np
+from matplotlib import pyplot as plt
+from pyCRTM import pyCRTM, profilesCreate
+ 
+def main(sensor_id):
+    thisDir = os.path.dirname(os.path.abspath(__file__))
+    cases = os.listdir( os.path.join(thisDir,'data') )
+    cases.sort()
+    # create 4 profiles for each of the 4 cases
+    profiles = profilesCreate( 4, 92 )
+    storedTb = []
+    storedEmis = []
+    sub = np.asarray([5,10,15],dtype=int)
+    pyIdx = sub - 1
+    
+    # populate the cases, and previously calculated Tb from crtm test program.    
+    for i,c in enumerate(cases):
+        h5 = h5py.File(os.path.join(thisDir,'data',c) , 'r')
+        profiles.Angles[i,0] = h5['zenithAngle'][()]
+        profiles.Angles[i,1] = 999.9 
+        profiles.Angles[i,2] = 100.0  # 100 degrees zenith below horizon.
+        profiles.Angles[i,3] = 0.0 # zero solar azimuth 
+        profiles.Angles[i,4] = h5['scanAngle'][()]
+        profiles.DateTimes[i,0] = 2001
+        profiles.DateTimes[i,1] = 1
+        profiles.DateTimes[i,2] = 1
+        profiles.Pi[i,:] = np.asarray(h5['pressureLevels'] )
+        profiles.P[i,:] = np.asarray(h5['pressureLayers'][()])
+        profiles.T[i,:] = np.asarray(h5['temperatureLayers'])
+        profiles.Q[i,:] = np.asarray(h5['humidityLayers'])
+        profiles.O3[i,:] = np.asarray(h5['ozoneConcLayers'])
+        profiles.clouds[i,:,0,0] = np.asarray(h5['cloudConcentration'])
+        profiles.clouds[i,:,0,1] = np.asarray(h5['cloudEffectiveRadius'])
+        profiles.aerosols[i,:,0,0] = np.asarray(h5['aerosolConcentration'])
+        profiles.aerosols[i,:,0,1] = np.asarray(h5['aerosolEffectiveRadius'])
+        profiles.aerosolType[i] = h5['aerosolType'][()]
+        profiles.cloudType[i] = h5['cloudType'][()]
+        profiles.cloudFraction[i,:] = h5['cloudFraction'][()]
+        profiles.climatology[i] = h5['climatology'][()]
+        profiles.surfaceFractions[i,:] = h5['surfaceFractions']
+        profiles.surfaceTemperatures[i,:] = h5['surfaceTemperatures']
+        profiles.Salinity[i] = 33.0 
+        profiles.windSpeed10m[i] = 5.0
+        profiles.LAI[i] = h5['LAI'][()]
+        profiles.windDirection10m[i] = h5['windDirection10m'][()]
+        # land, soil, veg, water, snow, ice
+        profiles.surfaceTypes[i,0] = h5['landType'][()]
+        profiles.surfaceTypes[i,1] = h5['soilType'][()]
+        profiles.surfaceTypes[i,2] = h5['vegType'][()]
+        profiles.surfaceTypes[i,3] = h5['waterType'][()]
+        profiles.surfaceTypes[i,4] = h5['snowType'][()]
+        profiles.surfaceTypes[i,5] = h5['iceType'][()]
+        storedTb.append(np.asarray(h5['Tb_atms'])[pyIdx])
+        storedEmis.append(np.asarray(h5['emissivity_atms'])[pyIdx])
+        h5.close()
+    crtmOb = pyCRTM()
+    crtmOb.profiles = profiles
+    crtmOb.sensor_id = sensor_id
+    crtmOb.nThreads = 1
+
+    crtmOb.loadInst()
+    # crtm inst must be loaded first before specifying channel subset
+    crtmOb.channelSubset = sub
+    crtmOb.runDirect()
+    forwardTb = crtmOb.Bt
+    forwardEmissivity = crtmOb.surfEmisRefl[0,:]
+    crtmOb.surfEmisRefl = []
+
+    crtmOb.runK()
+    kTb = crtmOb.Bt
+    kEmissivity = crtmOb.surfEmisRefl[0,:]
+
+    if ( all( np.abs( forwardTb.flatten() - np.asarray(storedTb).flatten() ) <= 1e-5)  and all( np.abs( kTb.flatten() - np.asarray(storedTb).flatten() ) <= 1e-5) ):
+        print("Yay! all values are close enough to what CRTM test program produced!")
+    else: 
+        print("Boo! something failed.")
+
+
+if __name__ == "__main__":
+    sensor_id = 'atms_npp'
+    main(sensor_id)
+ 

--- a/testCases/test_atms_subset_cloudnames.py
+++ b/testCases/test_atms_subset_cloudnames.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+import os, h5py, sys 
+import numpy as np
+from matplotlib import pyplot as plt
+from pyCRTM import pyCRTM, profilesCreate,WATER_CLOUD,ICE_CLOUD,RAIN_CLOUD,SNOW_CLOUD,GRAUPEL_CLOUD,HAIL_CLOUD
+ 
+def main(sensor_id):
+    thisDir = os.path.dirname(os.path.abspath(__file__))
+    cases = os.listdir( os.path.join(thisDir,'data') )
+    cases.sort()
+    # create 4 profiles for each of the 4 cases
+    profiles = profilesCreate( 4, 92 )
+    storedTb = []
+    storedEmis = []
+    sub = np.asarray([5,10,15],dtype=int)
+    pyIdx = sub - 1
+    
+    # populate the cases, and previously calculated Tb from crtm test program.    
+    for i,c in enumerate(cases):
+        h5 = h5py.File(os.path.join(thisDir,'data',c) , 'r')
+        profiles.Angles[i,0] = h5['zenithAngle'][()]
+        profiles.Angles[i,1] = 999.9 
+        profiles.Angles[i,2] = 100.0  # 100 degrees zenith below horizon.
+        profiles.Angles[i,3] = 0.0 # zero solar azimuth 
+        profiles.Angles[i,4] = h5['scanAngle'][()]
+        profiles.DateTimes[i,0] = 2001
+        profiles.DateTimes[i,1] = 1
+        profiles.DateTimes[i,2] = 1
+        profiles.Pi[i,:] = np.asarray(h5['pressureLevels'] )
+        profiles.P[i,:] = np.asarray(h5['pressureLayers'][()])
+        profiles.T[i,:] = np.asarray(h5['temperatureLayers'])
+        profiles.Q[i,:] = np.asarray(h5['humidityLayers'])
+        profiles.O3[i,:] = np.asarray(h5['ozoneConcLayers'])
+        profiles.clouds[i,:,0,0] = np.asarray(h5['cloudConcentration'])
+        profiles.clouds[i,:,0,1] = np.asarray(h5['cloudEffectiveRadius'])
+        profiles.aerosols[i,:,0,0] = np.asarray(h5['aerosolConcentration'])
+        profiles.aerosols[i,:,0,1] = np.asarray(h5['aerosolEffectiveRadius'])
+        profiles.aerosolType[i] = h5['aerosolType'][()]
+        #profiles.cloudType[i] = h5['cloudType'][()]
+        if(i == 0 or i==2):
+            profiles.cloudType[i] = np.asarray([WATER_CLOUD])
+        elif(i==1 or i==3):
+            profiles.cloudType[i] = np.asarray([RAIN_CLOUD]) 
+        profiles.cloudFraction[i,:] = h5['cloudFraction'][()]
+        profiles.climatology[i] = h5['climatology'][()]
+        profiles.surfaceFractions[i,:] = h5['surfaceFractions']
+        profiles.surfaceTemperatures[i,:] = h5['surfaceTemperatures']
+        profiles.Salinity[i] = 33.0 
+        profiles.windSpeed10m[i] = 5.0
+        profiles.LAI[i] = h5['LAI'][()]
+        profiles.windDirection10m[i] = h5['windDirection10m'][()]
+        # land, soil, veg, water, snow, ice
+        profiles.surfaceTypes[i,0] = h5['landType'][()]
+        profiles.surfaceTypes[i,1] = h5['soilType'][()]
+        profiles.surfaceTypes[i,2] = h5['vegType'][()]
+        profiles.surfaceTypes[i,3] = h5['waterType'][()]
+        profiles.surfaceTypes[i,4] = h5['snowType'][()]
+        profiles.surfaceTypes[i,5] = h5['iceType'][()]
+        storedTb.append(np.asarray(h5['Tb_atms'])[pyIdx])
+        storedEmis.append(np.asarray(h5['emissivity_atms'])[pyIdx])
+        h5.close()
+    crtmOb = pyCRTM()
+    crtmOb.profiles = profiles
+    crtmOb.sensor_id = sensor_id
+    crtmOb.nThreads = 1
+    crtmOb.CloudCoeff_File = 'CloudCoeff_TAMU-11Sep2014.bin'
+    crtmOb.loadInst()
+    # crtm inst must be loaded first before specifying channel subset
+    crtmOb.channelSubset = sub
+    crtmOb.runDirect()
+    forwardTb = crtmOb.Bt
+    forwardEmissivity = crtmOb.surfEmisRefl[0,:]
+    crtmOb.surfEmisRefl = []
+
+    crtmOb.runK()
+    kTb = crtmOb.Bt
+    kEmissivity = crtmOb.surfEmisRefl[0,:]
+
+    if ( all( np.abs( forwardTb.flatten() - np.asarray(storedTb).flatten() ) <= 1e-5)  and all( np.abs( kTb.flatten() - np.asarray(storedTb).flatten() ) <= 1e-5) ):
+        print("Yay! all values are close enough to what CRTM test program produced!")
+    else: 
+        print("Boo! something failed.")
+
+
+if __name__ == "__main__":
+    sensor_id = 'atms_npp'
+    main(sensor_id)
+ 

--- a/testCases/test_cris_subset.py
+++ b/testCases/test_cris_subset.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+import os, h5py, sys 
+import numpy as np
+from matplotlib import pyplot as plt
+from pyCRTM import pyCRTM, profilesCreate
+ 
+def main(sensor_id):
+    thisDir = os.path.dirname(os.path.abspath(__file__))
+    cases = os.listdir( os.path.join(thisDir,'data') )
+    cases.sort()
+    # create 4 profiles for each of the 4 cases
+    profiles = profilesCreate( 4, 92 )
+    storedTb = []
+    storedEmis = []
+    sub = np.asarray([5,10,15],dtype=int)
+    pyIdx = sub - 1
+    
+    # populate the cases, and previously calculated Tb from crtm test program.    
+    for i,c in enumerate(cases):
+        h5 = h5py.File(os.path.join(thisDir,'data',c) , 'r')
+        profiles.Angles[i,0] = h5['zenithAngle'][()]
+        profiles.Angles[i,1] = 999.9 
+        profiles.Angles[i,2] = 100.0  # 100 degrees zenith below horizon.
+        profiles.Angles[i,3] = 0.0 # zero solar azimuth 
+        profiles.Angles[i,4] = h5['scanAngle'][()]
+        profiles.DateTimes[i,0] = 2001
+        profiles.DateTimes[i,1] = 1
+        profiles.DateTimes[i,2] = 1
+        profiles.Pi[i,:] = np.asarray(h5['pressureLevels'] )
+        profiles.P[i,:] = np.asarray(h5['pressureLayers'][()])
+        profiles.T[i,:] = np.asarray(h5['temperatureLayers'])
+        profiles.Q[i,:] = np.asarray(h5['humidityLayers'])
+        profiles.O3[i,:] = np.asarray(h5['ozoneConcLayers'])
+        profiles.clouds[i,:,0,0] = np.asarray(h5['cloudConcentration'])
+        profiles.clouds[i,:,0,1] = np.asarray(h5['cloudEffectiveRadius'])
+        profiles.aerosols[i,:,0,0] = np.asarray(h5['aerosolConcentration'])
+        profiles.aerosols[i,:,0,1] = np.asarray(h5['aerosolEffectiveRadius'])
+        profiles.aerosolType[i] = h5['aerosolType'][()]
+        profiles.cloudType[i] = h5['cloudType'][()]
+        profiles.cloudFraction[i,:] = h5['cloudFraction'][()]
+        profiles.climatology[i] = h5['climatology'][()]
+        profiles.surfaceFractions[i,:] = h5['surfaceFractions']
+        profiles.surfaceTemperatures[i,:] = h5['surfaceTemperatures']
+        profiles.Salinity[i] = 33.0 
+        profiles.windSpeed10m[i] = 5.0
+        profiles.LAI[i] = h5['LAI'][()]
+        profiles.windDirection10m[i] = h5['windDirection10m'][()]
+        # land, soil, veg, water, snow, ice
+        profiles.surfaceTypes[i,0] = h5['landType'][()]
+        profiles.surfaceTypes[i,1] = h5['soilType'][()]
+        profiles.surfaceTypes[i,2] = h5['vegType'][()]
+        profiles.surfaceTypes[i,3] = h5['waterType'][()]
+        profiles.surfaceTypes[i,4] = h5['snowType'][()]
+        profiles.surfaceTypes[i,5] = h5['iceType'][()]
+        storedTb.append(np.asarray(h5['Tb_cris'])[pyIdx])
+        storedEmis.append(np.asarray(h5['emissivity_cris'])[pyIdx])
+        h5.close()
+    crtmOb = pyCRTM()
+    crtmOb.profiles = profiles
+    crtmOb.sensor_id = sensor_id
+    crtmOb.nThreads = 1
+
+    crtmOb.loadInst()
+    # crtm inst must be loaded first before specifying channel subset
+    crtmOb.channelSubset = sub
+    crtmOb.runDirect()
+    forwardTb = crtmOb.Bt
+    forwardEmissivity = crtmOb.surfEmisRefl[0,:]
+    crtmOb.surfEmisRefl = []
+
+    crtmOb.runK()
+    kTb = crtmOb.Bt
+    kEmissivity = crtmOb.surfEmisRefl[0,:]
+
+    if ( all( np.abs( forwardTb.flatten() - np.asarray(storedTb).flatten() ) <= 1e-5)  and all( np.abs( kTb.flatten() - np.asarray(storedTb).flatten() ) <= 1e-5) ):
+        print("Yay! all values are close enough to what CRTM test program produced!")
+    else: 
+        print("Boo! something failed.")
+
+
+if __name__ == "__main__":
+    sensor_id = 'cris_npp'
+    main(sensor_id)
+ 


### PR DESCRIPTION
Add capability to subset channels, cloud type shortcuts, and specify cloud and aerosol coefficient files

## Description
This adds features requested by Andy Lambert at NRL. I thought adding the capability to subset was useful enough, and could come handy in the future. Actually, not sure why I didn't add it earlier as it would have made my life easier with some applications. Anyway... 
* Adds the ability to use the subsetting feature of the CRTM (CRTM_ChannelInfo_Subset)
* Adds cloud variables (index used by the CRTM)
* Adds the capability for the user to specify which Aerosol or Cloud coefficient file is used (still only selects binary)
* Adds scripts (testCases) to test new features. 

## Definition of Done

No milestone, just adds additional capability/usability. 

### Issue(s) addressed

## Dependencies
None.

## Impact
None. 
