### PR TITLE
bugfix for numpy deprecation of np.int

### DIFF
--- a/pyCRTM.py
+++ b/pyCRTM.py
@@ -200,7 +200,7 @@ class pyCRTM:
         max_abs = len(self.usedGases)
         nprof, nlay = self.profiles.T.shape 
         self.traceConc = np.zeros([nprof,nlay,max_abs])
-        self.traceIds = np.zeros(max_abs, dtype=np.int)
+        self.traceIds = np.zeros(max_abs, dtype=int)
 
         #Fill array with what the user specified in profile.
         for i,g in enumerate(self.usedGases):


### PR DESCRIPTION
## Description
Removes deprecated numpy syntax. 

## Definition of Done

Fixes numpy syntax.

### Issue(s) addressed
Fixes a bug where recent versions of numpy will fail complaining np.int is deprecated. 

## Dependencies
None

## Impact
None

Note: to automatically run saber, ioda and ufo tests with this PR, push a commit containing "trigger pipeline", e.g.:
git commit --allow-empty -m 'trigger pipeline'
