### PR TITLE
fix uninitialized self.nChan_jacobian

### DIFF
--- a/pyCRTM.py
+++ b/pyCRTM.py
@@ -157,6 +157,7 @@ class pyCRTM:
         self.channelSubset = []
         self.subsetOn = False
         self.nChan = 0
+        self.nChan_jacobian = 0
         self.output_tb_flag = True
         self.output_cloud_K = False
         self.output_aerosol_K = False


### PR DESCRIPTION
## Description

I forgot to initialize one of the parameters I added on the last update adding cloud jacobians. It breaks the other examples when it runs Kmatrix. 

## Issue(s) addressed
None

## Dependencies

None
## Impact

Expected impact on downstream repositories:

## Checklist

- [ x] I have performed a self-review of my own code
- [ x] I have made corresponding changes to the documentation
- [ x] I have run the unit tests before creating the PR
